### PR TITLE
Fix %hookf

### DIFF
--- a/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
+++ b/bin/lib/Logos/Generator/MobileSubstrate/Function.pm
@@ -49,7 +49,7 @@ sub initializers {
 	my $function = shift;
 
 	my $return = "";
-	$return .= " MSHookFunction(".$function->name;
+	$return .= " MSHookFunction((void *)&".$function->name;
 	$return .= ", (void *)&".$self->newFunctionName($function);
 	$return .= ", (void **)&".$self->originalFunctionName($function);
 	$return .= ");";


### PR DESCRIPTION
Casts function name as void\* to fix "no matching function for call to 'MSHookFunction'" error.
