### PR TITLE
Symlink Linux.mk to Linux-x86_64.mk

### DIFF
--- a/makefiles/platform/Linux-x86_64.mk
+++ b/makefiles/platform/Linux-x86_64.mk
@@ -1,0 +1,1 @@
+Linux.mk


### PR DESCRIPTION
There is probably a better way of doing this, but this works for now see kirb/theos#10
